### PR TITLE
Update adapter installation command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ your specifications.
 1. Install an adapter (e.g. `@mojotech/prismatest-css`):
 
     ```bash
-    yarn install --dev @mojotech/prismatest-css
+    yarn add --dev @mojotech/prismatest-css
     ```
 
 2. Use some of the default test views to interact with your app:


### PR DESCRIPTION
Running `yarn install` doesn't actually install a package as per the [docs](https://classic.yarnpkg.com/en/docs/cli/install/), `yarn add` should be used instead